### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 dream-net.py"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DreamSploit
 ## DreamSec Exploit Console
 #### Alpha v1.0.0
-
+[![Run on Repl.it](https://repl.it/badge/github/Julz4455/DreamSploit)](https://repl.it/github/Julz4455/DreamSploit)
 Love metasploit but want to use python more than ruby? Well, you're in luck!
 DreamSploit is:
 - Metasploit Inspired


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@JulzTDG/DreamSploit).